### PR TITLE
paddingの調整

### DIFF
--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -2,11 +2,11 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center" class="pb-0 pt-5">
+      <v-col align="center" class="pb-0 mt-12">
         <v-card
           max-width="70vw"
           min-width="70vw"
-          class="py-10"
+          class="mt-12"
           :elevation="0"
         >
           <v-card-item>

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0 pt-5">
         <v-card
           max-width="70vw"
           min-width="70vw"

--- a/pages/goodies/index.vue
+++ b/pages/goodies/index.vue
@@ -2,11 +2,11 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center" class="pb-0 pt-5">
+      <v-col align="center" class="pb-0 mt-12">
         <v-card
           max-width="70vw"
           min-width="70vw"
-          class="py-10"
+          class="mt-12"
           :elevation="0"
         >
           <v-card-item>

--- a/pages/goodies/index.vue
+++ b/pages/goodies/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0 pt-5">
         <v-card
           max-width="70vw"
           min-width="70vw"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0">
         <v-card
           min-width="100vw"
           class="py-10"

--- a/pages/policies/index.vue
+++ b/pages/policies/index.vue
@@ -2,11 +2,11 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center" class="pb-0 pt-5">
+      <v-col align="center" class="pb-0 mt-12">
         <v-card
           max-width="70vw"
           min-width="70vw"
-          class="py-10"
+          class="mt-12"
           :elevation="0"
         >
           <v-card-item>

--- a/pages/policies/index.vue
+++ b/pages/policies/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0 pt-5">
         <v-card
           max-width="70vw"
           min-width="70vw"

--- a/pages/schedule/index.vue
+++ b/pages/schedule/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0 pt-5">
         <v-card
           max-width="80vw"
           min-width="80vw"

--- a/pages/schedule/index.vue
+++ b/pages/schedule/index.vue
@@ -2,11 +2,11 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center" class="pb-0 pt-5">
+      <v-col align="center" class="pb-0 mt-12">
         <v-card
           max-width="80vw"
           min-width="80vw"
-          class="py-10"
+          class="mt-12"
           :elevation="0"
         >
           <v-card-item>

--- a/pages/speakers/index.vue
+++ b/pages/speakers/index.vue
@@ -2,11 +2,11 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center" class="pb-0 pt-5">
+      <v-col align="center" class="pb-0 mt-12">
         <v-card
           max-width="70vw"
           min-width="70vw"
-          class="py-10"
+          class="mt-12"
           :elevation="0"
         >
           <v-card-item>

--- a/pages/speakers/index.vue
+++ b/pages/speakers/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0 pt-5">
         <v-card
           max-width="70vw"
           min-width="70vw"

--- a/pages/sponsors/index.vue
+++ b/pages/sponsors/index.vue
@@ -2,11 +2,11 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center" class="pb-0 pt-5">
+      <v-col align="center" class="pb-0 mt-12">
         <v-card
           max-width="70vw"
           min-width="70vw"
-          class="py-10"
+          class="mt-12"
           :elevation="0"
         >
           <v-card-item>

--- a/pages/sponsors/index.vue
+++ b/pages/sponsors/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0 pt-5">
         <v-card
           max-width="70vw"
           min-width="70vw"

--- a/pages/venue/index.vue
+++ b/pages/venue/index.vue
@@ -2,11 +2,11 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center" class="pb-0 pt-5">
+      <v-col align="center" class="pb-0 mt-12">
         <v-card
           max-width="70vw"
           min-width="70vw"
-          class="py-10"
+          class="mt-12"
           :elevation="0"
         >
           <v-card-item>

--- a/pages/venue/index.vue
+++ b/pages/venue/index.vue
@@ -2,7 +2,7 @@
   <v-app class="fill-height">
     <AppHeader />
     <v-row>
-      <v-col align="center">
+      <v-col align="center" class="pb-0 pt-5">
         <v-card
           max-width="70vw"
           min-width="70vw"


### PR DESCRIPTION
# Footer padding
デフォルトの`v-col`はpaddingが入っているみたいです。
<img width="1434" alt="スクリーンショット 2024-07-30 14 40 04" src="https://github.com/user-attachments/assets/042cfc36-b701-4e49-a707-ef1ee00b72b8">

各ページの`v-col`の下の方に`<FooterWave />`が入っていたのでフッターより下の方に空白が入ってしまいました。`<FooterWave />`を`v-col`の外に出すやり方もあるかと思いますが、とにかくpaddingを消しました。

# `v-col`, `v-card` padding
後は、少し分かりにくいですが、ロゴが少しだけnavbarに覆われていました。ここではっきりと見えるように`v-card`の`:elevation`を上げ、ボーダーラインをつけておきました。

### Before
<img width="924" alt="スクリーンショット 2024-07-30 15 16 27" src="https://github.com/user-attachments/assets/aadc9a9e-a7fd-4db9-a5f0-1d124075c180">

### After
<img width="941" alt="スクリーンショット 2024-07-30 15 09 43" src="https://github.com/user-attachments/assets/cff91f0d-4c4b-4cb7-a087-a78ff8ec4849">
