### PR TITLE
Tweak sponsor labels on the Sponsors page

### DIFF
--- a/pages/sponsors/index.vue
+++ b/pages/sponsors/index.vue
@@ -70,7 +70,7 @@
                 </v-row>
               </v-card>
               <h2 class="text-h4 title mb-2">
-                Hydration Sponsors
+                Hydration Sponsor
               </h2>
               <v-card
                 v-for="(custom, index) in customs"
@@ -121,7 +121,7 @@
                 </v-row>
               </v-card>
               <h2 class="text-h4 title mb-2">
-                Novelty Sponsors
+                Novelty Sponsor
               </h2>
               <v-card
                 v-for="(novelty, index) in novelties"


### PR DESCRIPTION
Hydration Sponsor と Novelty Sponsor は一社提供のようですので単数形にしました。

参考: https://rubykaigi.org/2023/sponsors/